### PR TITLE
Reenable handling of generic properties.

### DIFF
--- a/AssemblyToProcess/ParentWithGenericBaseOfInt.cs
+++ b/AssemblyToProcess/ParentWithGenericBaseOfInt.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using AutoProperties;
+
+public class ParentWithGenericBaseOfString : GenericBaseSome<string>
+{
+}
+
+public class ParentWithGenericBaseOfInt : GenericBaseSome<int>
+{
+}
+
+public abstract class GenericBaseSome<TProperty> : ChangeTrackable
+{
+    public TProperty GenericProperty { get; set; }
+}
+
+
+public abstract class ChangeTrackable
+{
+    [InterceptIgnore]
+    public virtual HashSet<string> ChangedProperties { get; } = new HashSet<string>();
+
+    [SetInterceptor]
+    protected void SetValue<T>(string name, Type propertyType, PropertyInfo propertyInfo, object newValue, T genericNewValue,
+        ref T refToBackingField)
+    {
+        refToBackingField = genericNewValue;
+        ChangedProperties?.Add(name);
+    }
+
+    [GetInterceptor]
+    protected T GetValue<T>(string name, Type propertyType, PropertyInfo propertyInfo, object fieldValue, T genericFieldValue, ref T refToBackingField)
+    {
+        return genericFieldValue;
+    }
+}
+
+public class SomeClassWithoutGenerics : ChangeTrackable
+{
+    public int ValueProperty { get; set; }
+    public string ReferenceProperty { get; set; }
+    public string[] ArrayProperty { get; set; }
+}

--- a/AutoProperties.Fody/PropertyAccessorWeaver.cs
+++ b/AutoProperties.Fody/PropertyAccessorWeaver.cs
@@ -254,12 +254,7 @@ namespace AutoProperties.Fody
                         _logger.LogInfo($"\tSkip {property.Name}, has [InterceptIgnore]");
                         continue;
                     }
-
-                    if (property.PropertyType.IsGenericParameter)
-                    {
-                        _logger.LogWarning($"\tSkip {property.Name}, properties with generic property types are not supported!");
-                        continue;
-                    }
+                    
 
                     try
                     {
@@ -484,9 +479,12 @@ namespace AutoProperties.Fody
                                         yield return Instruction.Create(OpCodes.Ldfld, backingField.GetReference());
                                     }
 
-                                    yield return propertyType.IsValueType
-                                        ? Instruction.Create(OpCodes.Box, Import(propertyType))
-                                        : Instruction.Create(OpCodes.Castclass, Import(parameterType));
+                                    if (propertyType.IsGenericParameter || propertyType.IsValueType)
+                                    {
+                                        // we only need to box for value types or if type is generic (no cast for reference)
+                                        yield return Instruction.Create(OpCodes.Box, Import(propertyType));
+                                    }
+
                                     break;
 
                                 default:

--- a/Tests/InterceptorTests.cs
+++ b/Tests/InterceptorTests.cs
@@ -163,5 +163,40 @@ public class InterceptorTests
         Assert.Equal("Test", target.Prop2); 
         Assert.Equal("Test2", target.Prop3);
     }
-}
 
+    [Theory]
+    [InlineData("ParentWithGenericBaseOfInt")]
+    public void GenericBaseClassOfInt_Test([NotNull] string className)
+    {
+        var parent = _assembly.GetInstance(className);
+        parent.GenericProperty = 1;
+        Assert.Contains("GenericProperty", parent.ChangedProperties);
+    }
+
+    [Theory]
+    [InlineData("ParentWithGenericBaseOfString")]
+    public void GenericBaseClassOfString_Test([NotNull] string className)
+    {
+        var parent = _assembly.GetInstance(className);
+        parent.GenericProperty = "Hello";
+        Assert.Contains("GenericProperty", parent.ChangedProperties);
+    }
+
+    [Theory]
+    [InlineData("SomeClassWithoutGenerics")]
+    public void SomeClassWithoutGenerics_Test([NotNull] string className)
+    {
+        var parent = _assembly.GetInstance(className);
+        parent.ValueProperty = 43;
+        Assert.Contains("ValueProperty", parent.ChangedProperties);
+        Assert.Equal(parent.ValueProperty, 43);
+
+        parent.ReferenceProperty = "Hello";
+        Assert.Contains("ReferenceProperty", parent.ChangedProperties);
+        Assert.Equal(parent.ReferenceProperty, "Hello");
+
+        parent.ArrayProperty = new[] {"Hello", "World"};
+        Assert.Contains("ArrayProperty", parent.ChangedProperties);
+        Assert.Equal(parent.ArrayProperty,new[] {"Hello", "World"});
+    }
+}


### PR DESCRIPTION
Hello,

weaving for generic properties seems to work if the `object newValue` parameter of the SetInterceptor method is not casted. 

Best regards,
Peter